### PR TITLE
✨ 기존에 받아왔던 advice를 유지하는 기능

### DIFF
--- a/advice-generator/src/advice/AdviceCard.js
+++ b/advice-generator/src/advice/AdviceCard.js
@@ -1,12 +1,13 @@
 import "./AdviceCard.css";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const AdviceCard = () => {
     const [adviceNumber, setAdviceNumber] = useState(0);
     const [adviceContent, setAdviceContent] = useState("");
 
     const getAdvice = () => {
+        console.log("clicked");
         fetch("https://api.adviceslip.com/advice", {
             headers: {
                 Accept: "application / json",
@@ -15,10 +16,26 @@ const AdviceCard = () => {
         })
             .then((data) => data.json())
             .then((data) => {
+                console.log(data);
                 setAdviceNumber(data.slip.id);
                 setAdviceContent(data.slip.advice);
+                localStorage.setItem(
+                    "advice",
+                    JSON.stringify({
+                        number: data.slip.id,
+                        content: data.slip.advice,
+                    })
+                );
             });
     };
+
+    useEffect(() => {
+        const savedAdviceData = JSON.parse(localStorage.getItem("advice"));
+        if (savedAdviceData) {
+            setAdviceNumber(savedAdviceData.number);
+            setAdviceContent(savedAdviceData.content);
+        }
+    }, []);
 
     return (
         <div className="advice-container">


### PR DESCRIPTION
## 설명
API를 통해 받아왔던 advice 데이터를 localStorage에 저장해 렌더링 시 저장된 데이터를 화면에 띄움

## 변경 내용
API를 통해 advice 데이터를 받아올 때마다 localStorage에 저장합니다.
새로고침 시 화면을 렌더링할 때 useEffect를 사용하여 advice데이터가 존재하는지 확인하고,
데이터가 존재한다면 set함수를 통해 state를 변경합니다.

![새로고침 시 데이터가 유지되는 화면](https://github.com/elice-study-first/advice-generator-hayeon/assets/83688911/4e4111c1-7ccd-4983-8916-c2f748f2ea1d)

## 관련 이슈
#7 